### PR TITLE
Add shortcut bash scripts for most common use case training and video recording. 

### DIFF
--- a/scripts/record_video_a1_ppo.sh
+++ b/scripts/record_video_a1_ppo.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+CMD="python -m utils.record_video --algo ppo --env A1GymEnv-v0 -f logs --load-best"
+echo "Executing command: ${CMD}"
+eval $CMD

--- a/scripts/train_a1_ppo.sh
+++ b/scripts/train_a1_ppo.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+CMD="python train.py --algo ppo --env A1GymEnv-v0 --save-freq 100000 | tee run.log"
+echo "Executing command: ${CMD}"
+eval $CMD
+


### PR DESCRIPTION
Now we can do source scripts/train_a1_ppo.sh instead of typing out the full train command. Similarly, python scripts/record_video_a1_ppo.sh instead of the full command