### PR TITLE
Remove time feature wrapper by replacing it with a dummy wrapper

### DIFF
--- a/dgx/submit_job.sh
+++ b/dgx/submit_job.sh
@@ -9,5 +9,7 @@
 # For explanation of various settings above, see /apps/how-to/quick.reference01... in the DGX login node
 RL_BASELINES_DIR="/home/i2r/daniel_tan/DATA/rl-baselines3-zoo"
 SCRIPT="${RL_BASELINES_DIR}/dgx/train_a1_ppo.sh"
+# Collect all command-line args and pass to training script
+ARGS="$@"
 echo "Executing script ${SCRIPT} from repository ${RL_BASELINES_DIR}..."
-bash $SCRIPT $RL_BASELINES_DIR
+bash $SCRIPT $RL_BASELINES_DIR $ARGS

--- a/dgx/train_a1_ppo.sh
+++ b/dgx/train_a1_ppo.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 RL_BASELINES_DIR=$1
 
+# Collect all extra arguments to pass to training script
+EXTRA_ARGS="${@:1}"
+
 # First, cd to our git repository
 # Next, build the docker image and save it in the docker registry
 # This has to be done in the same command because it starts a subshell
@@ -37,4 +40,6 @@ fi
 # PBS pro scheduler automatically logs stderr and stdout so no need to manually do that
 CONTAINER_ID=$(docker ps -aqf "name=${CONTAINER_NAME}")
 echo "INFO: Running train.py in container ${CONTAINER_ID}..."
-nvidia-docker exec $CONTAINER_ID sh -c "cd ~/rl-baselines3-zoo && python train.py --algo ppo --env A1GymEnv-v0 --save-freq 100000"
+CMD="cd ~/rl-baselines3-zoo && python train.py --algo ppo --env A1GymEnv-v0 --save-freq 100000 ${EXTRA_ARGS}"
+echo "INFO: Running command ${CMD}"
+nvidia-docker exec $CONTAINER_ID sh -c $CMD

--- a/hyperparams/ppo.yml
+++ b/hyperparams/ppo.yml
@@ -158,6 +158,7 @@ HalfCheetahBulletEnv-v0: &pybullet-defaults
 
 A1GymEnv-v0:
   <<: *pybullet-defaults
+  env_wrapper: utils.wrappers.DummyWrapper
   policy_kwargs: "dict(log_std_init=-2,
                        ortho_init=False,
                        activation_fn=nn.ReLU,

--- a/utils/wrappers.py
+++ b/utils/wrappers.py
@@ -3,6 +3,16 @@ import numpy as np
 from sb3_contrib.common.wrappers import TimeFeatureWrapper  # noqa: F401 (backward compatibility)
 from scipy.signal import iirfilter, sosfilt, zpk2sos
 
+class DummyWrapper(gym.Wrapper):
+    """ Placeholder wrapper for when we don't want any of the other wrappers """
+    def __init__(self, env: gym.Env):
+        super(DummyWrapper, self).__init__(env)
+    
+    def reset(self):
+        return self.env.reset()
+
+    def step(self, action):
+        return self.env.step(action)
 
 class DoneOnSuccessWrapper(gym.Wrapper):
     """


### PR DESCRIPTION
By default, SB3 zoo PPO on A1GymEnv includes an environment wrapper called TimeFeatureWrapper. 
This is printed in stdout at the start of training: 

```
========== A1GymEnv-v0 ==========
Seed: 2604389549
Default hyperparameters for environment (ones being tuned will be overridden):
OrderedDict([('batch_size', 128),
             ('clip_range', 0.4),
             ('ent_coef', 0.0),
             ('env_wrapper', 'sb3_contrib.common.wrappers.TimeFeatureWrapper'),
             ('gae_lambda', 0.9),
             ('gamma', 0.99),
             ('learning_rate', 3e-05),
             ('max_grad_norm', 0.5),
             ('n_envs', 16),
             ('n_epochs', 20),
             ('n_steps', 512),
             ('n_timesteps', 2000000.0),
             ('normalize', True),
             ('policy', 'MlpPolicy'),
             ('policy_kwargs',
              'dict(log_std_init=-2, ortho_init=False, activation_fn=nn.ReLU, '
              'net_arch=[dict(pi=[256, 256], vf=[256, 256])] )'),
             ('sde_sample_freq', 4),
             ('use_sde', True),
             ('vf_coef', 0.5)])
```

TimeFeatureWrapper simply adds a 1-dim feature of the number of steps remaining in the environment (see https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/blob/master/sb3_contrib/common/wrappers/time_feature.py). 

However it's not appropriate to include this because our agent should not depend on the time left in the environment (which is entirely artificial anyway). 

The PR fixes this by creating a dummy wrapper that does nothing and making that the default wrapper instead of TimeFeatureWrapper. 