### PR TITLE
Pin versions of pre-commit, black, and flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # cpu version of pytorch - faster to download
-        pip install torch==1.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+        pip install torch==1.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
         # temp fix: use pybullet 3.0.8 (issue with numpy for 3.0.9)
         pip install pybullet==3.0.8
         pip install -r requirements/main.txt
@@ -46,7 +46,7 @@ jobs:
         black --check blind_walking --line-length=127
     - name: Lint with flake8
       run: |
-        flake8 blind_walking --ignore=W503,W504,E203,E231,F841,F401,E402
+        flake8 --ignore=W503,W504,E203,E231,F841,F401,E402 blind_walking 
     - name: Test with pytest
       run: |
         python -m pytest tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.7b0
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.8
         args: ["blind_walking", --line-length=127]
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.9.2
     hooks:
       - id: flake8
-        additional_dependencies: [-e, "git+git://github.com/pycqa/pyflakes.git@1911c20#egg=pyflakes"]
-        args: ["blind_walking", "--ignore=W503,W504,E203,E231,F841,F401,E402"]
+        additional_dependencies: [-e, "git+git://github.com/pycqa/pyflakes.git#egg=pyflakes"]
+        args: ["--ignore=W503,W504,E203,E231,F841,F401,E402", "blind_walking"]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.5.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,9 @@
 sphinx>=3.3.1
 nbsphinx>=0.8.0
 sphinx-rtd-theme>=0.5.0
-flake8>=3.8.4
-mypy>=0.902
-black>=21.4b2
+flake8==3.9.2
+black==21.7b0
 pytest>=6.0.1
 types-pyyaml>=0.1.6
 types-termcolor>=0.1.0
-pre-commit>=2.7.1
+pre-commit==2.15


### PR DESCRIPTION
Fix the inconsistencies between pre-commit and CI workflow (hopefully). 

This is achieved by: 
1. Pinning specific version of pre-commit, black, and flake8 in `requirements/dev.txt` (used by Github CI)
2. Pinning specific version of black and flake8 in `.pre-commit-config.yaml` (used by `pre-commit`) 
3. Ensure command line args are exactly the same