### PR TITLE
Modify way in which dependencies are installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt install ffmpeg
         python -m pip install --upgrade pip
         # cpu version of pytorch - faster to download
         pip install torch==1.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
         # temp fix: use pybullet 3.0.8 (issue with numpy for 3.0.9)
         pip install pybullet==3.0.8
-        pip install -r requirements/main.txt
-        pip install -r requirements/dev.txt
+        pip install -e .[dev]
         # Use headless version
         pip install opencv-python-headless
         # install parking-env to test HER


### PR DESCRIPTION
This PR aims to fix the failing `test_hover_robot` test case. 
Error message: 
```
 ----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "blind_walking/examples/hover_robot.py", line 13, in <module>
    from blind_walking.envs.env_modifiers.env_modifier import EnvModifier
ModuleNotFoundError: No module named 'blind_walking'
```

I am unable to reproduce this on my own device, I can only think it's because of the way dependencies are installed in the github workflow. 
