### PR TITLE
Enable manual reset of TrainMultiple

### DIFF
--- a/blind_walking/envs/env_modifiers/train_course.py
+++ b/blind_walking/envs/env_modifiers/train_course.py
@@ -139,7 +139,7 @@ class TrainMultiple(EnvModifier):
         self.adjust_position = (x_pos, 0, z_pos)
 
     def _reset_randomly(self, env):
-        if np.random.uniform() < 1:
+        if np.random.uniform() < 0.5:
             # See heightfield
             self._reset_to_heightfield()
         else:

--- a/blind_walking/envs/env_modifiers/train_course.py
+++ b/blind_walking/envs/env_modifiers/train_course.py
@@ -97,6 +97,7 @@ class TrainMultiple(EnvModifier):
         self.stairs = []
         for _ in range(self.num_levels):
             self.stairs.append(Stairs())
+        self._reset_manual_override = None
 
     def _generate(self, env):
         self.hf._generate(env, start_x=10, heightPerturbationRange=self.hf_perturb)
@@ -149,11 +150,11 @@ class TrainMultiple(EnvModifier):
 
     def _reset(self, env):
         if self._reset_manual_override is not None:
-            self._reset_manually(self._reset_manual_override)
+            self._reset_manually()
             # Remove override for subsequent resets
             self._reset_manual_override = None
         else:
-            self._reset_randomly()
+            self._reset_randomly(env)
 
     def _reset_manually(self):
         if self._reset_manual_override == "heightfield":

--- a/blind_walking/envs/locomotion_gym_env.py
+++ b/blind_walking/envs/locomotion_gym_env.py
@@ -503,3 +503,7 @@ class LocomotionGymEnv(gym.Env):
     @property
     def robot_class(self):
         return self._robot_class
+
+    @property
+    def modifiers(self):
+        return self._env_modifiers


### PR DESCRIPTION
Provides functionality for manually resetting TrainMultple to specific locations. 
This makes it easier to test agents with pre-defined environmental obstacles. 